### PR TITLE
Quick fixes for Osate 2.3.3 compatibility

### DIFF
--- a/SimpleControlSystem/Alisa-Consistency/src/alisa_consistency/ModelVerifications.java
+++ b/SimpleControlSystem/Alisa-Consistency/src/alisa_consistency/ModelVerifications.java
@@ -3,18 +3,13 @@ package alisa_consistency;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.osate.aadl2.Classifier;
-import org.osate.aadl2.ComponentCategory;
-import org.osate.aadl2.ComponentImplementation;
-import org.osate.aadl2.ComponentType;
-import org.osate.aadl2.NamedElement;
 import org.osate.aadl2.Property;
 import org.osate.aadl2.UnitLiteral;
 import org.osate.aadl2.instance.ComponentInstance;
 import org.osate.aadl2.instance.FeatureCategory;
 import org.osate.aadl2.instance.FeatureInstance;
-import org.osate.aadl2.instance.InstanceObject;
-import org.osate.result.Issue;
-import org.osate.result.Result;
+import org.osate.result.AnalysisResult;
+import org.osate.result.Diagnostic;
 import org.osate.result.util.ResultUtil;
 import org.osate.xtext.aadl2.properties.util.GetProperties;
 import org.osate.xtext.aadl2.properties.util.PropertyUtils;
@@ -42,8 +37,8 @@ public class ModelVerifications {
 	 * Recursively consistency check that all leaf components have all features
 	 * connected. Get report back on details of which ones do not.
 	 */ // EList<ResultIssue>
-	public static Result allComponentFeaturesConnected(ComponentInstance ci) {
-		Result report = ResultUtil.createResult("AllFeaturesConnected", ci);
+	public static AnalysisResult allComponentFeaturesConnected(ComponentInstance ci) {
+		AnalysisResult report = ResultUtil.createAnalysisResult("AllFeaturesConnected", ci);
 		for (ComponentInstance subi : ci.getAllComponentInstances()) {
 			if (isLeafComponent(subi)) {
 				for (FeatureInstance fi : subi.getAllFeatureInstances()) {
@@ -51,11 +46,11 @@ public class ModelVerifications {
 						// PHF: in the next stable release (2.3.3) createFail will take only two parameters.
 						// PHF: The last parameter will need to be deleted
 						// PHF: change is supported by nightly build
-						Issue issue = ResultUtil.createFail(
+						Diagnostic issue = ResultUtil.createFailure(
 								"Feature " + fi.getName() + " of component "
 										+ fi.getContainingComponentInstance().getName() + " not connected",
-								fi, "AllFeatureConnected");
-						report.getIssues().add(issue);
+								fi);
+						report.getDiagnostics().add(issue);
 					}
 				}
 			}

--- a/SimpleControlSystem/SimpleControlSystem/resolute/BudgetResolute.aadl
+++ b/SimpleControlSystem/SimpleControlSystem/resolute/BudgetResolute.aadl
@@ -66,7 +66,7 @@ annex Resolute {**
 -- PHF: {} will need to be changed to []
 -- PHF: change is supported by nightly build
 	AddSubcomponentWeightBudgets(self: component) : real = 
-		sum({WeightBudget(t) for (t: subcomponents(self))})
+		sum([WeightBudget(t) for (t: subcomponents(self))])
 
 	-- recursively total of weight budgets of all components
 	AddAllBudgets(self : component) : real = 
@@ -75,7 +75,7 @@ annex Resolute {**
 -- PHF: The sum operator will only work on lists.
 -- PHF: {} will need to be changed to []
 -- PHF: change is supported by nightly build
-	let totals: real = sum({AddAllBudgets(t) for (t: subs)}) + NetWeight(self);
+	let totals: real = sum([AddAllBudgets(t) for (t: subs)]) + NetWeight(self);
 	if (length(subs) = 0 or totals = 0.0) then
 		WeightBudget(self)
 	else
@@ -107,7 +107,7 @@ SubcomponentsHaveWeightBudget(self:component): bool =
 -- PHF: {} will need to be changed to []
 -- PHF: change is supported by nightly build
 SubcomponentWeightBudgetCoveragePercent(self:component): int = let subs: {component} = subcomponents(self); 
- sum({ 100 for (sub : subs) | has_property(sub,SEI::GrossWeight)})/ (length(subs))
+ sum([100 for (sub : subs) | has_property(sub,SEI::GrossWeight)])/ (length(subs))
  
  
  AllComponentsHaveGrossWeight(self : component) <= ** "Component " self " shall have a weight budget" ** 


### PR DESCRIPTION
I have updated Resolute syntax.
I have also updated the code to use the new ResultUtil API.
A warning remains, as AnalysisResult.getDiagnostics() is deprecated, but I have not found the corresponding recommended API.